### PR TITLE
port 23 merge test cases from reference

### DIFF
--- a/kustomizer/src/patch/openapi/v2.rs
+++ b/kustomizer/src/patch/openapi/v2.rs
@@ -401,7 +401,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn minimize_openapi_v2_spec() -> anyhow::Result<()> {
         let reader = flate2::read::GzDecoder::new(
             include_bytes!("./openapi-v2-kubernetes-1.32.json.gz").as_ref(),

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-element-empty-list-src/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-element-empty-list-src/deployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo
+        image: foo:v1
+      - name: bar
+        image: bar:v1
+        command: ['run2.sh']

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-element-empty-list-src/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-element-empty-list-src/kustomization.yaml
@@ -1,0 +1,12 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      template:
+        spec:
+          containers: []

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-element-empty-list-src/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-element-empty-list-src/output.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: foo
+          image: foo:v1
+        - name: bar
+          image: bar:v1
+          command:
+            - run2.sh

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-element-empty-list-src/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-element-empty-list-src/test.yaml
@@ -1,0 +1,1 @@
+name: keep-element-empty-list-src

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-element-empty-list-src/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-element-empty-list-src/test.yaml
@@ -1,1 +1,2 @@
 name: keep-element-empty-list-src
+# Ported from: kustomize/kyaml/yaml/merge2/element_test.go - "keep element -- empty list in src"

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-element-missing-in-src/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-element-missing-in-src/deployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo
+        image: foo:v0
+      - name: bar
+        image: bar:v1
+        command: ['run2.sh']

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-element-missing-in-src/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-element-missing-in-src/kustomization.yaml
@@ -1,0 +1,14 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      template:
+        spec:
+          containers:
+          - name: foo
+            image: foo:v1

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-element-missing-in-src/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-element-missing-in-src/output.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: foo
+          image: foo:v1
+        - name: bar
+          image: bar:v1
+          command:
+            - run2.sh

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-element-missing-in-src/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-element-missing-in-src/test.yaml
@@ -1,0 +1,1 @@
+name: keep-element-missing-in-src

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-element-missing-in-src/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-element-missing-in-src/test.yaml
@@ -1,1 +1,2 @@
 name: keep-element-missing-in-src
+# Ported from: kustomize/kyaml/yaml/merge2/element_test.go - "keep Element -- element missing in src"

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-list-same-value/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-list-same-value/deployment.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+items:
+- 1
+- 2
+- 3

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-list-same-value/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-list-same-value/kustomization.yaml
@@ -1,0 +1,12 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test
+    items:
+    - 1
+    - 2
+    - 3

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-list-same-value/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-list-same-value/output.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+items:
+  - 1
+  - 2
+  - 3

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-list-same-value/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-list-same-value/test.yaml
@@ -1,1 +1,2 @@
 name: keep-list-same-value
+# Ported from: kustomize/kyaml/yaml/merge2/list_test.go - "keep List -- same value in src and dest"

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-list-same-value/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-list-same-value/test.yaml
@@ -1,0 +1,1 @@
+name: keep-list-same-value

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-list-unspecified/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-list-unspecified/deployment.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+items:
+- 1
+- 2
+- 3

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-list-unspecified/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-list-unspecified/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-list-unspecified/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-list-unspecified/output.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+items:
+  - 1
+  - 2
+  - 3

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-list-unspecified/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-list-unspecified/test.yaml
@@ -1,0 +1,3 @@
+kind: success
+# Ported from Go kustomize list_test.go - keep List -- unspecified in src
+# Tests that unspecified list in patch keeps original

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-map-empty-src/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-map-empty-src/deployment.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  foo: bar1
+  baz: buz

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-map-empty-src/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-map-empty-src/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test
+    items: {}

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-map-empty-src/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-map-empty-src/output.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  foo: bar1
+  baz: buz
+items:
+  {}

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-map-empty-src/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-map-empty-src/test.yaml
@@ -1,0 +1,1 @@
+name: keep-map-empty-src

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-map-empty-src/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-map-empty-src/test.yaml
@@ -1,1 +1,2 @@
 name: keep-map-empty-src
+# Ported from: kustomize/kyaml/yaml/merge2/map_test.go - "keep map -- empty list in src"

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-map-missing-from-src/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-map-missing-from-src/deployment.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  foo: bar1
+  baz: buz

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-map-missing-from-src/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-map-missing-from-src/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-map-missing-from-src/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-map-missing-from-src/output.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  foo: bar1
+  baz: buz

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-map-missing-from-src/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-map-missing-from-src/test.yaml
@@ -1,1 +1,2 @@
 name: keep-map-missing-from-src
+# Ported from: kustomize/kyaml/yaml/merge2/map_test.go - "keep map -- map missing from src"

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-map-missing-from-src/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-map-missing-from-src/test.yaml
@@ -1,0 +1,1 @@
+name: keep-map-missing-from-src

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-null-in-dest/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-null-in-dest/deployment.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+field: null

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-null-in-dest/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-null-in-dest/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-null-in-dest/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-null-in-dest/output.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+field: null

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-null-in-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-null-in-dest/test.yaml
@@ -1,0 +1,1 @@
+name: keep-scalar-null-in-dest

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-null-in-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-null-in-dest/test.yaml
@@ -1,1 +1,2 @@
 name: keep-scalar-null-in-dest
+# Ported from: kustomize/kyaml/yaml/merge2/scalar_test.go - "keep scalar -- missing in src, null in dest"

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-same-value/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-same-value/deployment.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+field: value1

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-same-value/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-same-value/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test
+    field: value1

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-same-value/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-same-value/output.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+field: value1

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-same-value/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-same-value/test.yaml
@@ -1,1 +1,2 @@
 name: keep-scalar-same-value
+# Ported from: kustomize/kyaml/yaml/merge2/scalar_test.go - "keep scalar -- same value in src and dest"

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-same-value/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-same-value/test.yaml
@@ -1,0 +1,1 @@
+name: keep-scalar-same-value

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-unspecified/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-unspecified/deployment.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+field: value1

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-unspecified/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-unspecified/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-unspecified/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-unspecified/output.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+field: value1

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-unspecified/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-unspecified/test.yaml
@@ -1,0 +1,1 @@
+name: keep-scalar-unspecified

--- a/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-unspecified/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/keep-scalar-unspecified/test.yaml
@@ -1,1 +1,2 @@
 name: keep-scalar-unspecified
+# Ported from: kustomize/kyaml/yaml/merge2/scalar_test.go - "keep scalar -- unspecified in src"

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-first/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-first/deployment.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo
+        image: foo:v0

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-first/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-first/kustomization.yaml
@@ -1,0 +1,17 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      template:
+        spec:
+          containers:
+          - name: bar
+            image: bar:v1
+            command: ['run2.sh']
+          - name: foo
+            image: foo:v1

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-first/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-first/output.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: foo
+          image: foo:v1
+        - name: bar
+          image: bar:v1
+          command:
+            - run2.sh

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-first/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-first/test.yaml
@@ -1,0 +1,1 @@
+name: merge-add-element-first

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-first/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-first/test.yaml
@@ -1,1 +1,2 @@
 name: merge-add-element-first
+# Ported from: kustomize/kyaml/yaml/merge2/element_test.go - "merge Element -- add Element first"

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-second/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-second/deployment.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo
+        image: foo:v0

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-second/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-second/kustomization.yaml
@@ -1,0 +1,17 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      template:
+        spec:
+          containers:
+          - name: foo
+            image: foo:v1
+          - name: bar
+            image: bar:v1
+            command: ['run2.sh']

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-second/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-second/output.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: foo
+          image: foo:v1
+        - name: bar
+          image: bar:v1
+          command:
+            - run2.sh

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-second/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-second/test.yaml
@@ -1,0 +1,1 @@
+name: merge-add-element-second

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-second/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-add-element-second/test.yaml
@@ -1,1 +1,2 @@
 name: merge-add-element-second
+# Ported from: kustomize/kyaml/yaml/merge2/element_test.go - "merge Element -- add Element second"

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-container-empty-dest/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-container-empty-dest/deployment.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers: []

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-container-empty-dest/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-container-empty-dest/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      template:
+        spec:
+          containers:
+          - name: foo
+            image: foo:v1
+            command: ['run.sh']

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-container-empty-dest/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-container-empty-dest/output.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: foo
+          image: foo:v1
+          command:
+            - run.sh

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-container-empty-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-container-empty-dest/test.yaml
@@ -1,1 +1,2 @@
 name: merge-container-empty-dest
+# Ported from: kustomize/kyaml/yaml/merge2/element_test.go - "merge Element -- add list, empty in dest"

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-container-empty-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-container-empty-dest/test.yaml
@@ -1,0 +1,1 @@
+name: merge-container-empty-dest

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-container-missing-from-dest/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-container-missing-from-dest/deployment.yaml
@@ -1,0 +1,4 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-container-missing-from-dest/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-container-missing-from-dest/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      template:
+        spec:
+          containers:
+          - name: foo
+            image: foo:v1
+            command: ['run.sh']

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-container-missing-from-dest/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-container-missing-from-dest/output.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: foo
+          image: foo:v1
+          command:
+            - run.sh

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-container-missing-from-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-container-missing-from-dest/test.yaml
@@ -1,1 +1,2 @@
 name: merge-container-missing-from-dest
+# Ported from: kustomize/kyaml/yaml/merge2/element_test.go - "merge Element -- add list, missing from dest"

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-container-missing-from-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-container-missing-from-dest/test.yaml
@@ -1,0 +1,1 @@
+name: merge-container-missing-from-dest

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-element-prepend/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-element-prepend/deployment.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo
+        image: foo:v0

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-element-prepend/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-element-prepend/kustomization.yaml
@@ -1,0 +1,17 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      template:
+        spec:
+          containers:
+          - name: bar
+            image: bar:v1
+            command: ['run2.sh']
+          - name: foo
+            image: foo:v1

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-element-prepend/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-element-prepend/output.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: foo
+          image: foo:v1
+        - name: bar
+          image: bar:v1
+          command:
+            - run2.sh

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-element-prepend/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-element-prepend/test.yaml
@@ -1,0 +1,1 @@
+name: merge-element-prepend

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-element-prepend/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-element-prepend/test.yaml
@@ -1,1 +1,2 @@
 name: merge-element-prepend
+# Ported from: kustomize/kyaml/yaml/merge2/element_test.go - "merge Element -- add Element third" (prepend direction)

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-empty-map-value/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-empty-map-value/deployment.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-empty-map-value/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-empty-map-value/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test
+    field: {}

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-empty-map-value/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-empty-map-value/output.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+field:
+  {}

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-empty-map-value/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-empty-map-value/test.yaml
@@ -1,0 +1,1 @@
+name: merge-empty-map-value

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-empty-map-value/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-empty-map-value/test.yaml
@@ -1,1 +1,2 @@
 name: merge-empty-map-value
+# Ported from: kustomize/kyaml/yaml/merge2/scalar_test.go - "merge an empty value"

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-keep-field-in-dest/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-keep-field-in-dest/deployment.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo
+        image: foo:v0
+        command: ['run.sh']

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-keep-field-in-dest/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-keep-field-in-dest/kustomization.yaml
@@ -1,0 +1,14 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      template:
+        spec:
+          containers:
+          - name: foo
+            image: foo:v1

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-keep-field-in-dest/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-keep-field-in-dest/output.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: foo
+          image: foo:v1
+          command:
+            - run.sh

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-keep-field-in-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-keep-field-in-dest/test.yaml
@@ -1,1 +1,2 @@
 name: merge-keep-field-in-dest
+# Ported from: kustomize/kyaml/yaml/merge2/element_test.go - "merge Element -- keep field in dest"

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-keep-field-in-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-keep-field-in-dest/test.yaml
@@ -1,0 +1,1 @@
+name: merge-keep-field-in-dest

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-add-field/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-add-field/deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  foo: bar0

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-add-field/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-add-field/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      foo: bar1
+      baz: buz

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-add-field/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-add-field/output.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  foo: bar1
+  baz: buz

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-add-field/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-add-field/test.yaml
@@ -1,0 +1,1 @@
+name: merge-map-add-field

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-add-field/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-add-field/test.yaml
@@ -1,1 +1,2 @@
 name: merge-map-add-field
+# Ported from: kustomize/kyaml/yaml/merge2/map_test.go - "merge Map -- add field to dest"

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-empty-dest/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-empty-dest/deployment.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+spec: {}

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-empty-dest/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-empty-dest/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      foo: bar1
+      baz: buz

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-empty-dest/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-empty-dest/output.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  foo: bar1
+  baz: buz

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-empty-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-empty-dest/test.yaml
@@ -1,1 +1,2 @@
 name: merge-map-empty-dest
+# Ported from: kustomize/kyaml/yaml/merge2/map_test.go - "merge Map -- add list, empty in dest"

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-empty-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-empty-dest/test.yaml
@@ -1,0 +1,1 @@
+name: merge-map-empty-dest

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-missing-from-dest/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-missing-from-dest/deployment.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-missing-from-dest/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-missing-from-dest/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      foo: bar1
+      baz: buz

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-missing-from-dest/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-missing-from-dest/output.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  foo: bar1
+  baz: buz

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-missing-from-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-missing-from-dest/test.yaml
@@ -1,0 +1,1 @@
+name: merge-map-missing-from-dest

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-missing-from-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-missing-from-dest/test.yaml
@@ -1,1 +1,2 @@
 name: merge-map-missing-from-dest
+# Ported from: kustomize/kyaml/yaml/merge2/map_test.go - "merge Map -- add list, missing from dest"

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-update-field/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-update-field/deployment.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  foo: bar0
+  baz: buz

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-update-field/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-update-field/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      foo: bar1

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-update-field/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-update-field/output.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  foo: bar1
+  baz: buz

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-update-field/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-update-field/test.yaml
@@ -1,0 +1,1 @@
+name: merge-map-update-field

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-map-update-field/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-map-update-field/test.yaml
@@ -1,1 +1,2 @@
 name: merge-map-update-field
+# Ported from: kustomize/kyaml/yaml/merge2/map_test.go - "merge Map -- update field in dest"

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-volumes-append/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-volumes-append/deployment.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      volumes:
+      - name: foo0

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-volumes-append/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-volumes-append/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: foo1
+          - name: foo2
+          - name: foo3

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-volumes-append/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-volumes-append/output.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      volumes:
+        - name: foo0
+        - name: foo1
+        - name: foo2
+        - name: foo3

--- a/kustomizer/tests/kustomizer/testdata/reference/merge-volumes-append/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/merge-volumes-append/test.yaml
@@ -1,0 +1,3 @@
+kind: success
+# Ported from Go kustomize list_test.go - merge k8s deployment volumes - append
+# Tests merging volumes with append behavior

--- a/kustomizer/tests/kustomizer/testdata/reference/port-patch-different-port-number/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/port-patch-different-port-number/kustomization.yaml
@@ -1,0 +1,12 @@
+resources:
+- service.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: web
+    spec:
+      ports:
+      - port: 30901
+        targetPort: 30901

--- a/kustomizer/tests/kustomizer/testdata/reference/port-patch-different-port-number/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/port-patch-different-port-number/output.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+    - port: 30900
+      targetPort: 30900
+      protocol: TCP
+    - port: 30901
+      targetPort: 30901

--- a/kustomizer/tests/kustomizer/testdata/reference/port-patch-different-port-number/service.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/port-patch-different-port-number/service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+  - port: 30900
+    targetPort: 30900
+    protocol: TCP

--- a/kustomizer/tests/kustomizer/testdata/reference/port-patch-different-port-number/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/port-patch-different-port-number/test.yaml
@@ -1,1 +1,2 @@
 name: port-patch-different-port-number
+# Ported from: kustomize/kyaml/yaml/merge2/map_test.go - "port patch has no protocol and different port number"

--- a/kustomizer/tests/kustomizer/testdata/reference/port-patch-different-port-number/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/port-patch-different-port-number/test.yaml
@@ -1,0 +1,1 @@
+name: port-patch-different-port-number

--- a/kustomizer/tests/kustomizer/testdata/reference/remove-containers-null/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/remove-containers-null/deployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo
+        image: foo:v1
+      - name: bar
+        image: bar:v1
+        command: ['run2.sh']

--- a/kustomizer/tests/kustomizer/testdata/reference/remove-containers-null/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/remove-containers-null/kustomization.yaml
@@ -1,0 +1,12 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      template:
+        spec:
+          containers: null

--- a/kustomizer/tests/kustomizer/testdata/reference/remove-containers-null/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/remove-containers-null/output.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec: {}

--- a/kustomizer/tests/kustomizer/testdata/reference/remove-containers-null/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/remove-containers-null/test.yaml
@@ -1,0 +1,3 @@
+kind: success
+# Ported from Go kustomize element_test.go - remove Element -- null in src
+# Tests that null containers removes entire containers field

--- a/kustomizer/tests/kustomizer/testdata/reference/remove-list-empty-src/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/remove-list-empty-src/deployment.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+items:
+- 1
+- 2
+- 3

--- a/kustomizer/tests/kustomizer/testdata/reference/remove-list-empty-src/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/remove-list-empty-src/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test
+    items: []

--- a/kustomizer/tests/kustomizer/testdata/reference/remove-list-empty-src/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/remove-list-empty-src/output.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+items:
+  []

--- a/kustomizer/tests/kustomizer/testdata/reference/remove-list-empty-src/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/remove-list-empty-src/test.yaml
@@ -1,0 +1,1 @@
+name: remove-list-empty-src

--- a/kustomizer/tests/kustomizer/testdata/reference/remove-list-empty-src/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/remove-list-empty-src/test.yaml
@@ -1,1 +1,2 @@
 name: remove-list-empty-src
+# Ported from: kustomize/kyaml/yaml/merge2/list_test.go - "remove list -- empty in src"

--- a/kustomizer/tests/kustomizer/testdata/reference/remove-scalar-null-missing-dest/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/remove-scalar-null-missing-dest/deployment.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test

--- a/kustomizer/tests/kustomizer/testdata/reference/remove-scalar-null-missing-dest/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/remove-scalar-null-missing-dest/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test
+    field: null

--- a/kustomizer/tests/kustomizer/testdata/reference/remove-scalar-null-missing-dest/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/remove-scalar-null-missing-dest/output.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test

--- a/kustomizer/tests/kustomizer/testdata/reference/remove-scalar-null-missing-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/remove-scalar-null-missing-dest/test.yaml
@@ -1,0 +1,1 @@
+name: remove-scalar-null-missing-dest

--- a/kustomizer/tests/kustomizer/testdata/reference/remove-scalar-null-missing-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/remove-scalar-null-missing-dest/test.yaml
@@ -1,1 +1,2 @@
 name: remove-scalar-null-missing-dest
+# Ported from: kustomize/kyaml/yaml/merge2/scalar_test.go - "remove scalar -- null in src, missing in dest"

--- a/kustomizer/tests/kustomizer/testdata/reference/replace-list-different-value/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/replace-list-different-value/deployment.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+items:
+- 0
+- 1

--- a/kustomizer/tests/kustomizer/testdata/reference/replace-list-different-value/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/replace-list-different-value/kustomization.yaml
@@ -1,0 +1,12 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test
+    items:
+    - 1
+    - 2
+    - 3

--- a/kustomizer/tests/kustomizer/testdata/reference/replace-list-different-value/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/replace-list-different-value/output.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+items:
+  - 1
+  - 2
+  - 3

--- a/kustomizer/tests/kustomizer/testdata/reference/replace-list-different-value/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/replace-list-different-value/test.yaml
@@ -1,0 +1,1 @@
+name: replace-list-different-value

--- a/kustomizer/tests/kustomizer/testdata/reference/replace-list-different-value/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/replace-list-different-value/test.yaml
@@ -1,1 +1,2 @@
 name: replace-list-different-value
+# Ported from: kustomize/kyaml/yaml/merge2/list_test.go - "replace List -- different value in dest"

--- a/kustomizer/tests/kustomizer/testdata/reference/replace-list-missing-from-dest/deployment.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/replace-list-missing-from-dest/deployment.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test

--- a/kustomizer/tests/kustomizer/testdata/reference/replace-list-missing-from-dest/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/replace-list-missing-from-dest/kustomization.yaml
@@ -1,0 +1,12 @@
+resources:
+- deployment.yaml
+patches:
+- patch: |
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      name: test
+    items:
+    - 1
+    - 2
+    - 3

--- a/kustomizer/tests/kustomizer/testdata/reference/replace-list-missing-from-dest/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/replace-list-missing-from-dest/output.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: test
+items:
+  - 1
+  - 2
+  - 3

--- a/kustomizer/tests/kustomizer/testdata/reference/replace-list-missing-from-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/replace-list-missing-from-dest/test.yaml
@@ -1,0 +1,1 @@
+name: replace-list-missing-from-dest

--- a/kustomizer/tests/kustomizer/testdata/reference/replace-list-missing-from-dest/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/reference/replace-list-missing-from-dest/test.yaml
@@ -1,1 +1,2 @@
 name: replace-list-missing-from-dest
+# Ported from: kustomize/kyaml/yaml/merge2/list_test.go - "replace List -- missing from dest"


### PR DESCRIPTION
Ported tests from merge2 test suite covering:
- Element merging (containers, volumes)
- Map field operations (update, add, keep, remove)
- Scalar field operations (null, empty, unspecified)
- List operations (replace, keep, remove)

no bugs discovered!