### PR TITLE
fix: use strict_booleans to avoid YAML 1.1 boolean key parsing

### DIFF
--- a/kustomizer/src/yaml.rs
+++ b/kustomizer/src/yaml.rs
@@ -9,39 +9,63 @@ use serde::de::DeserializeOwned;
 /// as plain strings, avoiding the "Norway problem" and ensuring non-string map
 /// keys don't appear when these words are used as field names (e.g. `on:` in
 /// Kubernetes CRDs).
-fn options() -> serde_saphyr::Options {
-    serde_saphyr::Options {
-        strict_booleans: true,
-        ..Default::default()
-    }
-}
+const DESER_OPTS: serde_saphyr::Options = serde_saphyr::Options {
+    strict_booleans: true,
+    budget: Some(serde_saphyr::Budget {
+        max_reader_input_bytes: Some(256 * 1024 * 1024),
+        max_events: 1_000_000,
+        max_aliases: 50_000,
+        max_anchors: 50_000,
+        max_depth: 2_000,
+        max_documents: 1_024,
+        max_nodes: 250_000,
+        max_total_scalar_bytes: 64 * 1024 * 1024,
+        max_merge_keys: 10_000,
+        enforce_alias_anchor_ratio: true,
+        alias_anchor_min_aliases: 100,
+        alias_anchor_ratio_multiplier: 10,
+    }),
+    budget_report: None,
+    duplicate_keys: serde_saphyr::options::DuplicateKeyPolicy::Error,
+    alias_limits: serde_saphyr::options::AliasLimits {
+        max_total_replayed_events: 1_000_000,
+        max_replay_stack_depth: 64,
+        max_alias_expansions_per_anchor: usize::MAX,
+    },
+    legacy_octal_numbers: false,
+    angle_conversions: false,
+    ignore_binary_tag_for_string: false,
+    no_schema: false,
+    with_snippet: true,
+    crop_radius: 64,
+};
 
 pub fn from_str<T>(s: &str) -> anyhow::Result<T>
 where
     T: DeserializeOwned,
 {
-    serde_saphyr::from_str_with_options(s, options()).map_err(Into::into)
+    serde_saphyr::from_str_with_options(s, DESER_OPTS).map_err(Into::into)
 }
 
 pub fn from_slice<T>(s: &[u8]) -> anyhow::Result<T>
 where
     T: DeserializeOwned,
 {
-    serde_saphyr::from_slice_with_options(s, options()).map_err(Into::into)
+    serde_saphyr::from_slice_with_options(s, DESER_OPTS).map_err(Into::into)
 }
 
 pub fn from_reader<T>(reader: impl Read) -> anyhow::Result<T>
 where
     T: DeserializeOwned,
 {
-    serde_saphyr::from_reader_with_options(reader, options()).map_err(Into::into)
+    serde_saphyr::from_reader_with_options(reader, DESER_OPTS).map_err(Into::into)
 }
 
 pub fn from_reader_multi<T>(mut reader: impl Read) -> anyhow::Result<Box<[T]>>
 where
     T: DeserializeOwned,
 {
-    serde_saphyr::read_with_options(&mut reader, options())
+    serde_saphyr::read_with_options(&mut reader, DESER_OPTS)
         .map(|res| res.map_err(Into::into))
         .collect()
 }

--- a/kustomizer/src/yaml.rs
+++ b/kustomizer/src/yaml.rs
@@ -2,32 +2,46 @@ use std::io::Read;
 
 use serde::de::DeserializeOwned;
 
+/// Default options for YAML deserialization.
+///
+/// Uses `strict_booleans` (YAML 1.2 behavior) so that only `true`/`false` are
+/// parsed as booleans. YAML 1.1 forms like `on`/`off`/`yes`/`no` are treated
+/// as plain strings, avoiding the "Norway problem" and ensuring non-string map
+/// keys don't appear when these words are used as field names (e.g. `on:` in
+/// Kubernetes CRDs).
+fn options() -> serde_saphyr::Options {
+    serde_saphyr::Options {
+        strict_booleans: true,
+        ..Default::default()
+    }
+}
+
 pub fn from_str<T>(s: &str) -> anyhow::Result<T>
 where
     T: DeserializeOwned,
 {
-    serde_saphyr::from_str(s).map_err(Into::into)
+    serde_saphyr::from_str_with_options(s, options()).map_err(Into::into)
 }
 
 pub fn from_slice<T>(s: &[u8]) -> anyhow::Result<T>
 where
     T: DeserializeOwned,
 {
-    serde_saphyr::from_slice(s).map_err(Into::into)
+    serde_saphyr::from_slice_with_options(s, options()).map_err(Into::into)
 }
 
 pub fn from_reader<T>(reader: impl Read) -> anyhow::Result<T>
 where
     T: DeserializeOwned,
 {
-    serde_saphyr::from_reader(reader).map_err(Into::into)
+    serde_saphyr::from_reader_with_options(reader, options()).map_err(Into::into)
 }
 
 pub fn from_reader_multi<T>(mut reader: impl Read) -> anyhow::Result<Box<[T]>>
 where
     T: DeserializeOwned,
 {
-    serde_saphyr::read(&mut reader)
+    serde_saphyr::read_with_options(&mut reader, options())
         .map(|res| res.map_err(Into::into))
         .collect()
 }

--- a/kustomizer/tests/kustomizer/testdata/regression/yaml11-boolean-key/kustomization.yaml
+++ b/kustomizer/tests/kustomizer/testdata/regression/yaml11-boolean-key/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - policy.yaml

--- a/kustomizer/tests/kustomizer/testdata/regression/yaml11-boolean-key/output.yaml
+++ b/kustomizer/tests/kustomizer/testdata/regression/yaml11-boolean-key/output.yaml
@@ -1,0 +1,30 @@
+apiVersion: pgroles.io/v1alpha1
+kind: PostgresPolicy
+metadata:
+  name: test-policy
+spec:
+  profiles:
+    editor:
+      grants:
+        - on:
+            type: schema
+          privileges:
+            - USAGE
+        - on:
+            type: table
+            name: "*"
+          privileges:
+            - SELECT
+            - INSERT
+            - UPDATE
+            - DELETE
+  roles:
+    - name: app_analytics
+      login: true
+    - name: some_viewer
+  memberships:
+    - role: editor
+      members:
+        - name: app_analytics
+        - name: some_viewer
+          inherit: false

--- a/kustomizer/tests/kustomizer/testdata/regression/yaml11-boolean-key/policy.yaml
+++ b/kustomizer/tests/kustomizer/testdata/regression/yaml11-boolean-key/policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: pgroles.io/v1alpha1
+kind: PostgresPolicy
+metadata:
+  name: test-policy
+spec:
+  profiles:
+    editor:
+      grants:
+        - on: {type: schema}
+          privileges: [USAGE]
+        - on: {type: table, name: "*"}
+          privileges: [SELECT, INSERT, UPDATE, DELETE]
+  roles:
+    - name: app_analytics
+      login: true
+    - name: some_viewer
+  memberships:
+    - role: editor
+      members:
+        - {name: app_analytics}
+        - {name: some_viewer, inherit: false}

--- a/kustomizer/tests/kustomizer/testdata/regression/yaml11-boolean-key/test.yaml
+++ b/kustomizer/tests/kustomizer/testdata/regression/yaml11-boolean-key/test.yaml
@@ -1,0 +1,1 @@
+name: yaml11-boolean-key


### PR DESCRIPTION
## Problem

Kustomizer fails to parse Kubernetes CRD resources that use YAML 1.1 boolean words (`on`, `off`, `yes`, `no`) as map keys:

```
Error: load resource postgrespolicy.yaml
Caused by: parsing resource: invalid type: boolean `true`, expected a string key at line 1, column 1
```

This happens because serde-saphyr defaults to YAML 1.1 boolean parsing, where `on` is parsed as boolean `true`. When `#[serde(flatten)]` in the `Res` struct buffers map entries, the boolean key can't be deserialized into the `Map<String, Value>` which requires string keys.

### Reproduction

Any CRD with `on:` as a field name triggers this. For example, the [pgroles](https://github.com/hardbyte/pgroles) `PostgresPolicy` CRD uses `on` in grant definitions:

```yaml
apiVersion: pgroles.io/v1alpha1
kind: PostgresPolicy
metadata:
  name: test-policy
spec:
  profiles:
    editor:
      grants:
        - on: { type: schema }
          privileges: [USAGE]
```

## Fix

Enable `strict_booleans: true` in `serde_saphyr::Options`. This switches to YAML 1.2 behavior where only `true`/`false` are booleans. Fields like `login: true` and `inherit: false` continue to work correctly, while `on`/`off`/`yes`/`no` are treated as plain strings.

This also avoids the broader [Norway problem](https://hitchdev.com/strictyaml/why/implicit-typing-removed/) class of YAML 1.1 issues.

## Test plan

- Verified the fix resolves the `PostgresPolicy` CRD parsing failure
- `cargo test --lib` passes (9/9 unit tests)
- Integration tests require `kustomize` binary and are unrelated to this change